### PR TITLE
Fix bounds of graphics configuration

### DIFF
--- a/projector-awt/src/main/kotlin/org/jetbrains/projector/awt/image/PGraphicsConfiguration.kt
+++ b/projector-awt/src/main/kotlin/org/jetbrains/projector/awt/image/PGraphicsConfiguration.kt
@@ -50,7 +50,7 @@ object PGraphicsConfiguration : GraphicsConfiguration() {
   }
 
   override fun getBounds(): Rectangle {
-    return Rectangle(PGraphicsDevice.bounds)
+    return PGraphicsDevice.clientScreenBounds
   }
 
   override fun createCompatibleVolatileImage(width: Int, height: Int, caps: ImageCapabilities?, transparency: Int): VolatileImage {

--- a/projector-awt/src/main/kotlin/org/jetbrains/projector/awt/image/PGraphicsConfiguration.kt
+++ b/projector-awt/src/main/kotlin/org/jetbrains/projector/awt/image/PGraphicsConfiguration.kt
@@ -50,7 +50,7 @@ object PGraphicsConfiguration : GraphicsConfiguration() {
   }
 
   override fun getBounds(): Rectangle {
-    return PGraphicsDevice.clientScreenBounds
+    return Rectangle(PGraphicsDevice.clientScreenBounds)
   }
 
   override fun createCompatibleVolatileImage(width: Int, height: Int, caps: ImageCapabilities?, transparency: Int): VolatileImage {


### PR DESCRIPTION
Fixes PRJ-101 
Fixes PRJ-218

On behalf of https://github.com/cdr

The bounds used by the graphics configuration have to match what's used by mouse events. Otherwise the shiftes coordinates could be outside of the device's boundaries.

## How to reproduce

1. Run an JetBrains IDE with projector. If a main window is opened, then File->Close project.
2. The dialog "Open Project" appears. At first it's briefly shown in the middle of the screen. Then it's moved to the top-left of the screen. This seems to leave a clientShift in the system, which is != [0,0].
3. Click "Open" on the welcome dialog. Click it. The file choose dialog couldn't be moved to the bottom-right position of the screen.
4. Move the window to the bottom-right position. Without this fix, this would be restricted to a part of the available screen.
5. Now pull the lower edge of the window downloads to resize
6. The window header is now pushed upwards. Try a few timese to move it out of the visible area.
7. Now the window can't be moved anymore because the header has become invisible