### PR TITLE
Add support for font ligatures

### DIFF
--- a/projector-awt/src/main/kotlin/org/jetbrains/projector/awt/image/PGraphics2D.kt
+++ b/projector-awt/src/main/kotlin/org/jetbrains/projector/awt/image/PGraphics2D.kt
@@ -204,7 +204,7 @@ class PGraphics2D private constructor(
 
   override fun drawGlyphVector(g: GlyphVector, x: Float, y: Float) {
     val shape = g.getOutline(x, y)
-    draw(shape)
+    fill(shape)
   }
 
   private fun paintShape(paintType: AwtPaintType, shape: Shape) {


### PR DESCRIPTION
On behalf of https://github.com/cdr/

Fixes:
https://youtrack.jetbrains.com/issue/PRJ-25
https://youtrack.jetbrains.com/issue/PRJ-221
https://youtrack.jetbrains.com/issue/PRJ-234

Inspired by other implementations of Graphics2D from the java.desktop module,
glyphs should be filled instead of stroking the character outline.

Before:
![image](https://user-images.githubusercontent.com/1479167/106283741-f310d280-624a-11eb-84f1-72598f2a60a5.png)

After:
![image](https://user-images.githubusercontent.com/1479167/106283793-07ed6600-624b-11eb-984b-0d46c8ed2af0.png)
