### PR TITLE
Fix compatibility with JetBrains Runtime bundled with 2021.1 EAP

### DIFF
--- a/projector-awt/src/main/kotlin/org/jetbrains/projector/awt/peer/PKeyboardFocusManagerPeer.kt
+++ b/projector-awt/src/main/kotlin/org/jetbrains/projector/awt/peer/PKeyboardFocusManagerPeer.kt
@@ -24,6 +24,7 @@ import sun.awt.KeyboardFocusManagerPeerImpl
 import java.awt.Component
 import java.awt.Window
 import java.awt.event.FocusEvent
+import java.lang.reflect.Method
 import java.util.concurrent.locks.ReentrantReadWriteLock
 import kotlin.concurrent.read
 import kotlin.concurrent.write
@@ -35,6 +36,38 @@ object PKeyboardFocusManagerPeer : KeyboardFocusManagerPeerImpl() {
   private val lock = ReentrantReadWriteLock(true)
 
   private var focusedWindow: Window? = null
+
+  /**
+   * In a recent build of JetBrains runtime, the signature changed from
+   *      boolean deliverFocus(Component lightweightChild, Component target,
+   *                        boolean temporary, boolean focusedWindowChangeAllowed, long time,
+   *                        FocusEvent.Cause cause, Component currentFocusOwner)
+   * to
+   *      boolean deliverFocus(Component lightweightChild, Component target,
+   *                        boolean highPriority,
+   *                        FocusEvent.Cause cause, Component currentFocusOwner)
+   *
+   * https://github.com/JetBrains/JetBrainsRuntime/commit/1a9838082e3eb48d43e6bac6a412463923173fc7#diff-5818ad29e3f2e395597b8565f3553ad139de16439414e3fc688412fb35bd57f4
+   */
+  private val deliverFocusMethod: Method
+  private val newDeliverFocusMethod: Boolean
+
+  init {
+    val result = try {
+      KeyboardFocusManagerPeerImpl::class.java.getMethod("deliverFocus",
+        Component::class.java, Component::class.java,
+        Boolean::class.java, Boolean::class.java, Long::class.java,
+        FocusEvent.Cause::class.java, Component::class.java) to false
+    } catch (e: NoSuchMethodException) {
+      KeyboardFocusManagerPeerImpl::class.java.getMethod("deliverFocus",
+        Component::class.java, Component::class.java,
+        Boolean::class.java,
+        FocusEvent.Cause::class.java, Component::class.java) to true
+    }
+
+    deliverFocusMethod = result.first
+    newDeliverFocusMethod = result.second
+  }
 
   override fun setCurrentFocusedWindow(window: Window) {
     lock.write {
@@ -68,6 +101,12 @@ object PKeyboardFocusManagerPeer : KeyboardFocusManagerPeerImpl() {
     time: Long,
     cause: FocusEvent.Cause,
   ): Boolean {
-    return deliverFocus(lightweightChild, target, temporary, focusedWindowChangeAllowed, time, cause, currentFocusOwner)
+    // JetBrains Runtime passes "false" on X11, we're doing the same here
+    // https://github.com/JetBrains/JetBrainsRuntime/blob/1a9838082e3eb48d43e6bac6a412463923173fc7/src/java.desktop/unix/classes/sun/awt/X11/XKeyboardFocusManagerPeer.java#L108
+
+    return when (newDeliverFocusMethod) {
+      true -> deliverFocusMethod.invoke(null, lightweightChild, target, false, cause, currentFocusOwner)
+      false -> deliverFocusMethod.invoke(null, lightweightChild, target, temporary, focusedWindowChangeAllowed, time, cause, currentFocusOwner)
+    } as Boolean
   }
 }


### PR DESCRIPTION
On behalf of https://github.com/cdr/

Fixes https://youtrack.jetbrains.com/issue/PRJ-289

This uses reflection to call the available method of the JDK. Let me know if you don't want the comments in the code, feel free to update the code at your preference.