### PR TITLE
Provide the font ligature attribute to client

### DIFF
--- a/projector-agent/src/main/kotlin/org/jetbrains/projector/agent/CommandsHandler.kt
+++ b/projector-agent/src/main/kotlin/org/jetbrains/projector/agent/CommandsHandler.kt
@@ -34,6 +34,7 @@ import org.jetbrains.projector.server.util.FontCacher
 import sun.font.FontDesignMetrics
 import java.awt.*
 import java.awt.font.FontRenderContext
+import java.awt.font.TextAttribute
 import java.awt.geom.AffineTransform
 import java.awt.geom.Rectangle2D
 import java.awt.image.BufferedImage
@@ -136,7 +137,13 @@ internal object CommandsHandler {
     is ServerDrawStringEvent -> listOf(
       createSetClipEvent(g.clip),
       ServerSetTransformEvent(tx = g.transform.toList()),
-      g.font.let { ServerSetFontEvent(fontId = FontCacher.getId(it), fontSize = it.size) },
+      g.font.let {
+        ServerSetFontEvent(
+          fontId = FontCacher.getId(it),
+          fontSize = it.size,
+          ligaturesOn = (it.attributes.getOrDefault(TextAttribute.LIGATURES, 0) as Int) > 0,
+        )
+      },
       ServerSetPaintEvent(createPaintValue(g.paint)),
       ServerSetCompositeEvent(g.composite.toCommonComposite()),
       paintEvent

--- a/projector-server/src/main/kotlin/org/jetbrains/projector/server/service/ProjectorDrawEventQueue.kt
+++ b/projector-server/src/main/kotlin/org/jetbrains/projector/server/service/ProjectorDrawEventQueue.kt
@@ -30,6 +30,7 @@ import org.jetbrains.projector.server.core.util.*
 import org.jetbrains.projector.server.util.*
 import org.jetbrains.projector.util.logging.Logger
 import java.awt.*
+import java.awt.font.TextAttribute
 import java.lang.ref.SoftReference
 import java.util.concurrent.ConcurrentLinkedQueue
 
@@ -73,7 +74,10 @@ class ProjectorDrawEventQueue private constructor(val target: ServerDrawCommands
     }
 
     override fun setFont(font: Font): DrawEventQueue.CommandBuilder {
-      events.add(ServerSetFontEvent(fontId = FontCacher.getId(font), fontSize = font.size))
+      events.add(ServerSetFontEvent(
+        fontId = FontCacher.getId(font),
+        fontSize = font.size,
+        ligaturesOn = (font.attributes.getOrDefault(TextAttribute.LIGATURES, 0) as Int) > 0))
       return this
     }
 


### PR DESCRIPTION
On behalf of https://github.com/cdr/

Related to:
https://youtrack.jetbrains.com/issue/PRJ-25
https://youtrack.jetbrains.com/issue/PRJ-221
https://youtrack.jetbrains.com/issue/PRJ-234

This should allow projector-client to disable font ligatures for simple
text.

Needs https://github.com/JetBrains/projector-client/pull/13 to be merged and published first.