### PR TITLE
Send data required to correctly calculate positions when drawing a speculative symbol

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -26,7 +26,7 @@ intellijPluginVersion=1.1.2
 javassistVersion=3.27.0-GA
 kotlinVersion=1.5.20
 mockitoKotlinVersion=3.2.0
-projectorClientVersion=fa179d0b
+projectorClientVersion=711542fb
 projectorClientGroup=com.github.JetBrains.projector-client
 targetJvm=11
 # Give JitPack some time to build projector-client:

--- a/projector-server/src/main/kotlin/org/jetbrains/projector/server/idea/CaretInfoUpdater.kt
+++ b/projector-server/src/main/kotlin/org/jetbrains/projector/server/idea/CaretInfoUpdater.kt
@@ -90,7 +90,7 @@ class CaretInfoUpdater(private val onCaretInfoChanged: (ServerCaretInfoChangedEv
     val visibleEditorRect = scrollPane.viewport.viewRect
 
     val lineHeight = focusedEditor.lineHeight
-    val lineDescent = focusedEditor.descent
+    val lineAscent = focusedEditor.ascent
 
     var rootComponent: Component? = focusedEditorComponent
     var editorPWindow: PWindow? = null
@@ -126,9 +126,8 @@ class CaretInfoUpdater(private val onCaretInfoChanged: (ServerCaretInfoChangedEv
           CaretInfo(point)
         }
 
-        val scrollBarWidth = if (visibleEditorRect.height < focusedEditorComponent.height) // check scrollbar should be visible
-          scrollPane.verticalScrollBar?.width ?: 0
-        else 0
+        val isVerticalScrollBarVisible = visibleEditorRect.height < focusedEditorComponent.height
+        val verticalScrollBarWidth = if (isVerticalScrollBarVisible) scrollPane.verticalScrollBar?.width ?: 0 else 0
 
         ServerCaretInfoChangedEvent.CaretInfoChange.Carets(
           points,
@@ -142,8 +141,8 @@ class CaretInfoUpdater(private val onCaretInfoChanged: (ServerCaretInfoChangedEv
             height = visibleEditorRect.height.toDouble()
           ),
           lineHeight = lineHeight,
-          lineDescent = lineDescent,
-          scrollBarWidth = scrollBarWidth,
+          lineAscent = lineAscent,
+          verticalScrollBarWidth = verticalScrollBarWidth,
         )
       }
     }


### PR DESCRIPTION
Added sending of:
- lineHeight (to calculate vertical position of a speculative symbol and height of area cut and moved to the right a speculative symbol)
- lineDescent (to calculate vertical position of a speculative symbol)
- scrollBarWidth (to calculate width of area cut and moved to the right of a speculative symbol)

Requires JetBrains/projector-client#38