### PR TITLE
Various changes for Swing client

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -26,6 +26,7 @@ javassistVersion=3.27.0-GA
 kotlinVersion=1.5.20
 mockitoKotlinVersion=3.2.0
 projectorClientVersion=8d16dbc2
+projectorClientGroup=com.github.JetBrains.projector-client
 targetJvm=11
 # Give JitPack some time to build projector-client:
 systemProp.org.gradle.internal.http.connectionTimeout=180000

--- a/projector-agent/build.gradle
+++ b/projector-agent/build.gradle
@@ -24,9 +24,9 @@ compileKotlin {
 }
 
 dependencies {
-  implementation("com.github.JetBrains.projector-client:projector-common:$projectorClientVersion")
-  implementation("com.github.JetBrains.projector-client:projector-server-core:$projectorClientVersion")
-  implementation("com.github.JetBrains.projector-client:projector-util-logging:$projectorClientVersion")
+  implementation("$projectorClientGroup:projector-common:$projectorClientVersion")
+  implementation("$projectorClientGroup:projector-server-core:$projectorClientVersion")
+  implementation("$projectorClientGroup:projector-util-logging:$projectorClientVersion")
   api(project(":projector-awt"))
   api(project(":projector-server"))
   implementation("org.javassist:javassist:$javassistVersion")

--- a/projector-awt/build.gradle.kts
+++ b/projector-awt/build.gradle.kts
@@ -36,9 +36,10 @@ publishing {
 
 val kotlinVersion: String by project
 val projectorClientVersion: String by project
+val projectorClientGroup: String by project
 version = project(":projector-server").version
 
 dependencies {
-  implementation("com.github.JetBrains.projector-client:projector-util-logging:$projectorClientVersion")
+  implementation("$projectorClientGroup:projector-util-logging:$projectorClientVersion")
   testImplementation(kotlin("test", kotlinVersion))
 }

--- a/projector-awt/src/main/kotlin/org/jetbrains/projector/awt/PWindow.kt
+++ b/projector-awt/src/main/kotlin/org/jetbrains/projector/awt/PWindow.kt
@@ -136,7 +136,7 @@ class PWindow(val target: Component, val isAgent: Boolean) {
     repaint()
   }
 
-  private fun updateGraphics() {
+  internal fun updateGraphics() {
     val windowMidpoint = with(target.bounds) { Point(x + width / 2, y + height / 2) }
     val newDevice = PGraphicsEnvironment.devices.minByOrNull {
       val deviceBounds = it.bounds
@@ -146,6 +146,8 @@ class PWindow(val target: Component, val isAgent: Boolean) {
       }
     } ?: return
     graphics.device = newDevice
+    graphics.transform = newDevice.configuration.defaultTransform
+    AWTAccessor.getComponentAccessor().setGraphicsConfiguration(target, newDevice.configuration)
   }
 
   fun move(deltaX: Int, deltaY: Int) {

--- a/projector-plugin/build.gradle.kts
+++ b/projector-plugin/build.gradle.kts
@@ -30,9 +30,10 @@ plugins {
 
 
 val projectorClientVersion: String by project
+val projectorClientGroup: String by project
 
 dependencies {
-  implementation("com.github.JetBrains.projector-client:projector-server-core:$projectorClientVersion")
+  implementation("$projectorClientGroup:projector-server-core:$projectorClientVersion")
   implementation(project(":projector-agent"))
 }
 

--- a/projector-server/build.gradle
+++ b/projector-server/build.gradle
@@ -48,9 +48,9 @@ configurations.all {
 }
 
 dependencies {
-  implementation("com.github.JetBrains.projector-client:projector-common:$projectorClientVersion")
-  implementation("com.github.JetBrains.projector-client:projector-server-core:$projectorClientVersion")
-  implementation("com.github.JetBrains.projector-client:projector-util-logging:$projectorClientVersion")
+  implementation("$projectorClientGroup:projector-common:$projectorClientVersion")
+  implementation("$projectorClientGroup:projector-server-core:$projectorClientVersion")
+  implementation("$projectorClientGroup:projector-util-logging:$projectorClientVersion")
   api project(":projector-awt")
 
   testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"

--- a/projector-server/src/main/kotlin/org/jetbrains/projector/server/ProjectorLauncher.kt
+++ b/projector-server/src/main/kotlin/org/jetbrains/projector/server/ProjectorLauncher.kt
@@ -67,7 +67,8 @@ object ProjectorLauncher {
     ProjectorFontProvider.isAgent = false
   }
 
-  private fun runProjectorServer(): Boolean {
+  @JvmStatic
+  fun runProjectorServer(): Boolean {
     System.setProperty(ProjectorServer.ENABLE_PROPERTY_NAME, true.toString())
 
     assert(ProjectorServer.isEnabled) { "Can't start the ${ProjectorServer::class.simpleName} because it's disabled..." }

--- a/projector-server/src/main/kotlin/org/jetbrains/projector/server/ProjectorServer.kt
+++ b/projector-server/src/main/kotlin/org/jetbrains/projector/server/ProjectorServer.kt
@@ -354,6 +354,10 @@ class ProjectorServer private constructor(
     Do exhaustive when (message) {
       is ClientResizeEvent -> SwingUtilities.invokeLater { resize(message.size.width, message.size.height) }
 
+      is ClientDisplaySetChangeEvent -> SwingUtilities.invokeLater {
+        PGraphicsEnvironment.setupDisplays(message.newDisplays.map { Rectangle(it.x, it.y, it.width, it.height) to it.scaleFactor })
+      }
+
       is ClientMouseEvent -> SwingUtilities.invokeLater {
         val shiftedMessage = message.shift(PGraphicsEnvironment.defaultDevice.clientShift)
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -35,6 +35,8 @@ pluginManagement {
 
 rootProject.name = "projector-server"
 
+val projectorClientGroup: String by settings
+
 val localProperties = Properties().apply {
   try {
     load(File(rootDir, "local.properties").inputStream())
@@ -47,9 +49,9 @@ val localProperties = Properties().apply {
 if (localProperties["useLocalProjectorClient"] == "true") {
   includeBuild("../projector-client") {
     dependencySubstitution {
-      substitute(module("com.github.JetBrains.projector-client:projector-common")).with(project(":projector-common"))
-      substitute(module("com.github.JetBrains.projector-client:projector-server-core")).with(project(":projector-server-core"))
-      substitute(module("com.github.JetBrains.projector-client:projector-util-logging")).with(project(":projector-util-logging"))
+      substitute(module("$projectorClientGroup:projector-common")).with(project(":projector-common"))
+      substitute(module("$projectorClientGroup:projector-server-core")).with(project(":projector-server-core"))
+      substitute(module("$projectorClientGroup:projector-util-logging")).with(project(":projector-util-logging"))
     }
   }
 }


### PR DESCRIPTION
* Different group is used in internal publishing
* `runProjectorServer` is invoked from CWM code as the generic launcher can't be used there
* Display configuration changes from client can be supported for cases where the client adds/removes displays or changes their resolution

Paired PR in client repository: [#40](https://github.com/JetBrains/projector-client/pull/40)