### PR TITLE
CI new release builder

### DIFF
--- a/.github/agent-release-drafter.yml
+++ b/.github/agent-release-drafter.yml
@@ -1,0 +1,26 @@
+name-template: 'v$NEXT_PATCH_VERSION'
+tag-template: 'v$NEXT_PATCH_VERSION'
+exclude-labels:
+  - 'skip-changelog'
+include-labels:
+  - 'agent:feature'
+  - 'agent:fix'
+  - 'agent:bug'
+  - 'agent:tests'
+
+categories:
+  - title: '🚀 New Features'
+    labels:
+      - 'agent:feature'
+
+  - title: '🐛 Fixes'
+    labels:
+      - 'agent:fix'
+      - 'agent:bug'
+
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+template: |
+  ## Changes
+  $CHANGES
+  ## Contributors
+  $CONTRIBUTORS

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,30 @@
+name-template: 'v$NEXT_PATCH_VERSION'
+tag-template: 'v$NEXT_PATCH_VERSION'
+exclude-labels:
+  - 'skip-changelog'
+include-labels:
+  - 'server:feature'
+  - 'server:fix'
+  - 'server:bug'
+  - 'server:tests'
+
+categories:
+  - title: '🚀 New Features'
+    labels:
+      - 'server:feature'
+
+  - title: '🐛 Fixes'
+    labels:
+      - 'server:fix'
+      - 'server:bug'
+
+  - title: '✅ Tests'
+    labels:
+      - 'server:tests'
+
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+template: |
+  ## Changes
+  $CHANGES
+  ## Contributors
+  $CONTRIBUTORS

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,4 +10,4 @@ jobs:
     steps:
       - uses: zwaldowski/match-label-action@v2
         with:
-          allowed: 'server:feature, server:fix, server:bug, server:tests, agent:feature, agent:fix, agent:bug, ci'
+          allowed: 'server:feature, server:fix, server:bug, server:tests, agent:feature, agent:fix, agent:bug, ci, skip-changelog'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,13 @@
+name: "Verify type labels"
+
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: zwaldowski/match-label-action@v2
+        with:
+          allowed: 'server:feature, server:fix, server:bug, server:tests, agent:feature, agent:fix, agent:bug, ci'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,4 +10,4 @@ jobs:
     steps:
       - uses: zwaldowski/match-label-action@v2
         with:
-          allowed: 'server:feature, server:fix, server:bug, server:tests, agent:feature, agent:fix, agent:bug, ci, skip-changelog'
+          allowed: 'server:feature, server:fix, server:bug, server:tests, agent:feature, agent:fix, agent:bug, skip-changelog'

--- a/.github/workflows/release-agent.yml
+++ b/.github/workflows/release-agent.yml
@@ -22,6 +22,9 @@ jobs:
           ./gradlew :projector-plugin:buildPlugin
           cd projector-plugin/build/distributions
           find . -maxdepth 1 -type f -name projector-plugin-*.zip -exec mv {} projector-plugin.zip \;
+      - name: Tag name  # Inspired from https://github.community/t/how-to-get-just-the-tag-name/16241/11
+        id: tag_name
+        run: echo ::set-output name=SOURCE_TAG::${GITHUB_REF#refs/tags/}
       - name: create draft release
         id: create_release
         uses: release-drafter/release-drafter@v5
@@ -30,9 +33,8 @@ jobs:
         with:
           disable-autolabeler: true
           config-name: agent-release-drafter.yml
-      - name: Tag name  # Inspired from https://github.community/t/how-to-get-just-the-tag-name/16241/11
-        id: tag_name
-        run: echo ::set-output name=SOURCE_TAG::${GITHUB_REF#refs/tags/}
+          name: Release ${{ steps.tag_name.outputs.SOURCE_TAG }}
+          tag: ${{ steps.tag_name.outputs.SOURCE_TAG }}
       - name: Upload Release Asset (agent)
         id: upload-release-asset
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/release-agent.yml
+++ b/.github/workflows/release-agent.yml
@@ -22,17 +22,14 @@ jobs:
           ./gradlew :projector-plugin:buildPlugin
           cd projector-plugin/build/distributions
           find . -maxdepth 1 -type f -name projector-plugin-*.zip -exec mv {} projector-plugin.zip \;
-      - name: Create Release
+      - name: create draft release
         id: create_release
-        uses: actions/create-release@v1
+        uses: release-drafter/release-drafter@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          draft: false
-          prerelease: false
-          body: Changelog is available in [CHANGELOG.md](https://github.com/JetBrains/projector-server/blob/master/projector-plugin/CHANGELOG.md).
+          disable-autolabeler: true
+          config-name: agent-release-drafter.yml
       - name: Tag name  # Inspired from https://github.community/t/how-to-get-just-the-tag-name/16241/11
         id: tag_name
         run: echo ::set-output name=SOURCE_TAG::${GITHUB_REF#refs/tags/}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,17 +22,11 @@ jobs:
           ./gradlew :projector-server:distZip
           cd projector-server/build/distributions
           find . -maxdepth 1 -type f -name projector-server-*.zip -exec mv {} projector-server.zip \;
-      - name: Create Release
+      - name: create draft release
         id: create_release
-        uses: actions/create-release@v1
+        uses: release-drafter/release-drafter@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          draft: false
-          prerelease: false
-          body: Changelog is available in [CHANGELOG.md](https://github.com/JetBrains/projector-server/blob/master/projector-server/CHANGELOG.md).
       - name: Tag name  # Inspired from https://github.community/t/how-to-get-just-the-tag-name/16241/11
         id: tag_name
         run: echo ::set-output name=SOURCE_TAG::${GITHUB_REF#refs/tags/}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,14 +22,17 @@ jobs:
           ./gradlew :projector-server:distZip
           cd projector-server/build/distributions
           find . -maxdepth 1 -type f -name projector-server-*.zip -exec mv {} projector-server.zip \;
+      - name: Tag name  # Inspired from https://github.community/t/how-to-get-just-the-tag-name/16241/11
+        id: tag_name
+        run: echo ::set-output name=SOURCE_TAG::${GITHUB_REF#refs/tags/}
       - name: create draft release
         id: create_release
         uses: release-drafter/release-drafter@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Tag name  # Inspired from https://github.community/t/how-to-get-just-the-tag-name/16241/11
-        id: tag_name
-        run: echo ::set-output name=SOURCE_TAG::${GITHUB_REF#refs/tags/}
+        with:
+          name: Release ${{ steps.tag_name.outputs.SOURCE_TAG }}
+          tag: ${{ steps.tag_name.outputs.SOURCE_TAG }}
       - name: Upload Release Asset
         id: upload-release-asset
         uses: actions/upload-release-asset@v1


### PR DESCRIPTION
It is a new release builder.
How does it work?
Look at that:
```yml
on:
  push:
    tags:
      - "v*"
```
```yml
on:
  push:
    tags:
      - "agent-v*"
 ```
After you pushed with tag `v*` or `agent-v*` trigger starts. In the tag, you need to write a version accurate to the patch because automatic versioning does not work in the context of our repository. The bot creates a new draft release, following the pattern provided in the `*release-drafter.yml`.  The bot will collect labeled pull requests and place them in the changelog according to the pattern. After the bot creates a draft release, you can find it in the "releases" tab at the root of the repository. You can correct the changelog.
![example1](https://sun9-2.userapi.com/impg/qvw89F54s-gUbU_wZAnIvokI3DSL7KrR12-bAQ/p3yt0erk9NI.jpg?size=2013x1119&quality=96&sign=d5af0a8ea0dd019ccb3204b6fd737089&type=album)
After that, you need to tap the `Publish release`, the second button. If you want to make a pre-release, you should tup the checkbox (1)
![example2](https://sun9-53.userapi.com/impg/LUTtA3HLoQ1vZNpGhLMyHvZ5S2YffFbTGfZ_UA/lm6F7nzlp3k.jpg?size=1118x1330&quality=96&sign=3f55e0312ee4fdda0ee837c8af4a531e&type=album)