### PR TITLE
Fix jar build error

### DIFF
--- a/projector-agent/build.gradle
+++ b/projector-agent/build.gradle
@@ -53,6 +53,7 @@ jar {
   }
 
   exclude("META-INF/versions/9/module-info.class")
+  duplicatesStrategy = DuplicatesStrategy.WARN
 
   from {
     inline(configurations.runtimeClasspath)  // todo: remove

--- a/projector-server/build.gradle
+++ b/projector-server/build.gradle
@@ -63,6 +63,7 @@ jar {
       "Main-Class": application.mainClassName,
       )
   }
+  duplicatesStrategy = DuplicatesStrategy.WARN
 }
 
 //Server running tasks


### PR DESCRIPTION
Added `WARN` strategy. 
Warn strategy do not attempt to prevent duplicates, but log a warning message when multiple items are to be created at the same path. This behaves exactly as INCLUDE otherwise.
