### PR TITLE
Fix NRE when creating font events

### DIFF
--- a/projector-agent/src/main/kotlin/org/jetbrains/projector/agent/CommandsHandler.kt
+++ b/projector-agent/src/main/kotlin/org/jetbrains/projector/agent/CommandsHandler.kt
@@ -146,7 +146,7 @@ internal object CommandsHandler {
         ServerSetFontEvent(
           fontId = FontCacher.getId(it),
           fontSize = it.size,
-          ligaturesOn = (it.attributes.getOrDefault(TextAttribute.LIGATURES, 0) as Int) > 0,
+          ligaturesOn = ((it.attributes[TextAttribute.LIGATURES] as Int?) ?: 0) > 0,
         )
       },
       ServerSetPaintEvent(createPaintValue(g.paint)),

--- a/projector-server/src/main/kotlin/org/jetbrains/projector/server/service/ProjectorDrawEventQueue.kt
+++ b/projector-server/src/main/kotlin/org/jetbrains/projector/server/service/ProjectorDrawEventQueue.kt
@@ -82,7 +82,7 @@ class ProjectorDrawEventQueue private constructor(val target: ServerDrawCommands
       events.add(ServerSetFontEvent(
         fontId = FontCacher.getId(font),
         fontSize = font.size,
-        ligaturesOn = (font.attributes.getOrDefault(TextAttribute.LIGATURES, 0) as Int) > 0))
+        ligaturesOn = ((font.attributes[TextAttribute.LIGATURES] as Int?) ?: 0) > 0))
       return this
     }
 


### PR DESCRIPTION
If a map explicitly stores `null` as the value, `getOrDefault` will happily return that `null` instead of the default.  
As such, a manual null check (or elvis in this case) is necessary.