### PR TITLE
Implement basic window draw interest management for server

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -26,7 +26,7 @@ intellijPluginVersion=1.1.2
 javassistVersion=3.27.0-GA
 kotlinVersion=1.5.20
 mockitoKotlinVersion=3.2.0
-projectorClientVersion=33ea1be3
+projectorClientVersion=385c3e9a
 projectorClientGroup=com.github.JetBrains.projector-client
 targetJvm=11
 # Give JitPack some time to build projector-client:

--- a/projector-awt/src/main/kotlin/org/jetbrains/projector/awt/PWindow.kt
+++ b/projector-awt/src/main/kotlin/org/jetbrains/projector/awt/PWindow.kt
@@ -40,7 +40,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import kotlin.math.abs
 import kotlin.math.min
 
-class PWindow private constructor(val target: Component, val isAgent: Boolean, graphicsOverride: Graphics2D?) {
+class PWindow private constructor(val target: Component, private val isAgent: Boolean, graphicsOverride: Graphics2D?) {
 
   constructor(target: Component, isAgent: Boolean) : this(target, isAgent, null)
 

--- a/projector-server/src/main/kotlin/org/jetbrains/projector/server/util/WindowDrawInterestManagerImpl.kt
+++ b/projector-server/src/main/kotlin/org/jetbrains/projector/server/util/WindowDrawInterestManagerImpl.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2019-2021, JetBrains s.r.o. and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation. JetBrains designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact JetBrains, Na Hrebenech II 1718/10, Prague, 14000, Czech Republic
+ * if you need additional information or have any questions.
+ */
+package org.jetbrains.projector.server.util
+
+import org.jetbrains.projector.awt.PWindow
+import org.jetbrains.projector.server.core.util.AbstractWindowDrawInterestManager
+
+class WindowDrawInterestManagerImpl : AbstractWindowDrawInterestManager() {
+  override fun redrawWindow(id: Int) {
+    PWindow.getWindow(id)?.repaint()
+  }
+
+
+}

--- a/projector-server/src/test/kotlin/org/jetbrains/projector/server/util/InterestManagerImplTest.kt
+++ b/projector-server/src/test/kotlin/org/jetbrains/projector/server/util/InterestManagerImplTest.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2019-2021, JetBrains s.r.o. and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation. JetBrains designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact JetBrains, Na Hrebenech II 1718/10, Prague, 14000, Czech Republic
+ * if you need additional information or have any questions.
+ */
+@file:Suppress("JAVA_MODULE_DOES_NOT_EXPORT_PACKAGE")
+package org.jetbrains.projector.server.util
+
+import org.jetbrains.projector.awt.PWindow
+import org.jetbrains.projector.common.protocol.toServer.ClientWindowInterestEvent
+import org.mockito.Mockito
+import java.awt.Graphics2D
+import javax.swing.JPanel
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class InterestManagerImplTest {
+
+  @Test
+  fun `test gaining interest triggers PWindow component redraw`() {
+    val interestManager = WindowDrawInterestManagerImpl()
+
+    var repaintCounter = 0
+    val dummyComponent = object: JPanel() {
+      override fun repaint() {
+        repaintCounter++
+      }
+    }
+    repaintCounter = 0 // reset it to ignore JPanel's own repaints
+
+    assertEquals(0, PWindow.windows.size, "test assumes there are no windows")
+
+    val window = PWindow.createWithGraphicsOverride(dummyComponent, true, Mockito.mock(Graphics2D::class.java, Mockito.CALLS_REAL_METHODS))
+    val windowId = window.id
+
+    try {
+      assertEquals(0, repaintCounter)
+
+      interestManager.processClientEvent(ClientWindowInterestEvent(windowId, false))
+      assertEquals(0, repaintCounter, "interest loss should not trigger repaint")
+
+      interestManager.processClientEvent(ClientWindowInterestEvent(windowId, true))
+      assertEquals(1, repaintCounter, "interest gain should trigger repaint")
+
+      interestManager.processClientEvent(ClientWindowInterestEvent(windowId, true))
+      assertEquals(1, repaintCounter, "repeated interest gain should not trigger repaint")
+
+      interestManager.processClientEvent(ClientWindowInterestEvent(windowId, false))
+      interestManager.processClientEvent(ClientWindowInterestEvent(windowId, true))
+      assertEquals(2, repaintCounter, "interest gain should trigger repaint")
+    } finally {
+      window.dispose()
+      assertEquals(0, PWindow.windows.size, "there should be no windows after test")
+    }
+  }
+}


### PR DESCRIPTION
While this feature is of little use for the web client currently, it is needed in IDEA/CWM to reduce network traffic overhead when the main IDEA window is not visible on the client

This implementation assumes that the client is interested in all windows by default, and lets the client mark specific windows as non-interesting. Draw events for non-interesting windows will be discarded when sent to that client.
Marking the window as interesting again will trigger a repaint to ensure that the client has up-to-date window state.

See [projector-client #68](https://github.com/JetBrains/projector-client/pull/68) for the corresponding PR in the client