### PR TITLE
Refactor server to support multiple transports natively

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -26,7 +26,7 @@ intellijPluginVersion=1.1.2
 javassistVersion=3.27.0-GA
 kotlinVersion=1.5.20
 mockitoKotlinVersion=3.2.0
-projectorClientVersion=385c3e9a
+projectorClientVersion=f1e52565
 projectorClientGroup=com.github.JetBrains.projector-client
 targetJvm=11
 # Give JitPack some time to build projector-client:

--- a/projector-server/src/main/kotlin/org/jetbrains/projector/server/ProjectorServer.kt
+++ b/projector-server/src/main/kotlin/org/jetbrains/projector/server/ProjectorServer.kt
@@ -666,7 +666,7 @@ class ProjectorServer private constructor(
     updateThread = createUpdateThread()
     caretInfoUpdater.start()
 
-    if (getProperty(NO_WS_TRANSPORT_PROPERTY)?.toBoolean() != true) {
+    if (getProperty(ENABLE_WS_TRANSPORT_PROPERTY)?.toBoolean() != false) {
       addTransport(WebsocketServer.createTransportBuilder().attachDefaultServerEventHandlers(clientEventHandler).build())
     }
   }
@@ -872,7 +872,7 @@ class ProjectorServer private constructor(
     private const val DEFAULT_PORT = 8887
     const val TOKEN_ENV_NAME = "ORG_JETBRAINS_PROJECTOR_SERVER_HANDSHAKE_TOKEN"
     const val RO_TOKEN_ENV_NAME = "ORG_JETBRAINS_PROJECTOR_SERVER_RO_HANDSHAKE_TOKEN"
-    const val NO_WS_TRANSPORT_PROPERTY = "org.jetbrains.projector.server.websocket.disable"
+    const val ENABLE_WS_TRANSPORT_PROPERTY = "ORG_JETBRAINS_PROJECTOR_SERVER_ENABLE_WS_TRANSPORT"
 
     var ENABLE_BIG_COLLECTIONS_CHECKS = System.getProperty("org.jetbrains.projector.server.debug.collections.checks") == "true"
     private const val DEFAULT_BIG_COLLECTIONS_CHECKS_SIZE = 10_000

--- a/projector-server/src/main/kotlin/org/jetbrains/projector/server/ProjectorServer.kt
+++ b/projector-server/src/main/kotlin/org/jetbrains/projector/server/ProjectorServer.kt
@@ -218,7 +218,7 @@ class ProjectorServer private constructor(
     }
   }
 
-  private val clientsObservers: MutableList<PropertyChangeListener> = Collections.synchronizedList(ArrayList<PropertyChangeListener>())
+  private val clientsObservers = Collections.synchronizedList(mutableListOf<PropertyChangeListener>())
   fun addClientsObserver(listener: PropertyChangeListener) = clientsObservers.add(listener)
   fun removeClientsObserver(listener: PropertyChangeListener) = clientsObservers.remove(listener)
 
@@ -861,6 +861,7 @@ class ProjectorServer private constructor(
       }
     }
 
+    @Suppress("MemberVisibilityCanBePrivate")  // used in CWM
     var lastStartedServer: ProjectorServer? = null
       private set
 

--- a/projector-server/src/main/kotlin/org/jetbrains/projector/server/util/ConfirmConnection.kt
+++ b/projector-server/src/main/kotlin/org/jetbrains/projector/server/util/ConfirmConnection.kt
@@ -27,11 +27,11 @@ import java.net.InetAddress
 import javax.swing.JLabel
 import javax.swing.JOptionPane
 
-class ConfirmConnection(ip: InetAddress?, private val accessType: String)
+class ConfirmConnection private constructor(private val accessType: String)
   : JLabel(), ResolvedHostSubscriber {
   private val resolver = AsyncHostResolver()
 
-  init {
+  constructor(ip: InetAddress?, accessType: String) : this(accessType) {
     text = if (ip != null) {
       resolver.resolve(this, ip)
       getMessage(ip.hostAddress)
@@ -39,6 +39,10 @@ class ConfirmConnection(ip: InetAddress?, private val accessType: String)
     else {
       getMessage("unknown host")
     }
+  }
+
+  constructor(hostName: String, accessType: String) : this(accessType) {
+    text = getMessage(hostName)
   }
 
   private fun getMessage(host: String) = "<html>Somebody from $host wants to connect with $accessType access. " +
@@ -49,11 +53,11 @@ class ConfirmConnection(ip: InetAddress?, private val accessType: String)
   }
 
   companion object {
-    fun confirm(ip: InetAddress?, accessType: String): Boolean {
-      val message = ConfirmConnection(ip, accessType)
-      val result = JOptionPane.showConfirmDialog(null, message,
-                                                 "New connection", JOptionPane.OK_CANCEL_OPTION)
-      return result == JOptionPane.OK_OPTION
-    }
+    fun confirm(ip: InetAddress?, accessType: String) = ConfirmConnection(ip, accessType).doShow()
+
+    fun confirm(hostName: String, accessType: String) = ConfirmConnection(hostName, accessType).doShow()
+
+    private fun ConfirmConnection.doShow() =
+      JOptionPane.showConfirmDialog(null, this, "New connection", JOptionPane.OK_CANCEL_OPTION) == JOptionPane.OK_OPTION
   }
 }

--- a/projector-server/src/main/kotlin/org/jetbrains/projector/server/websocket/WebsocketServer.kt
+++ b/projector-server/src/main/kotlin/org/jetbrains/projector/server/websocket/WebsocketServer.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2019-2021, JetBrains s.r.o. and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation. JetBrains designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact JetBrains, Na Hrebenech II 1718/10, Prague, 14000, Czech Republic
+ * if you need additional information or have any questions.
+ */
+package org.jetbrains.projector.server.websocket
+
+import org.jetbrains.projector.common.protocol.data.ImageData
+import org.jetbrains.projector.common.protocol.data.ImageId
+import org.jetbrains.projector.common.protocol.toClient.MainWindow
+import org.jetbrains.projector.server.ProjectorServer
+import org.jetbrains.projector.server.core.util.getProperty
+import org.jetbrains.projector.server.core.websocket.HttpWsClientBuilder
+import org.jetbrains.projector.server.core.websocket.HttpWsServerBuilder
+import org.jetbrains.projector.server.core.websocket.MultiTransportBuilder
+import org.jetbrains.projector.server.core.websocket.WsTransportBuilder
+import org.jetbrains.projector.server.service.ProjectorImageCacher
+import org.jetbrains.projector.util.logging.Logger
+
+object WebsocketServer {
+  internal fun createTransportBuilder(): WsTransportBuilder {
+    val builders = arrayListOf<WsTransportBuilder>()
+
+    val relayUrl = getProperty(RELAY_PROPERTY_NAME)
+    val serverId = getProperty(SERVER_ID_PROPERTY_NAME)
+
+    if (relayUrl != null && serverId != null) {
+      val scheme = when (getProperty(RELAY_USE_WSS)?.toBoolean() ?: true) {
+        false -> "ws"
+        true -> "wss"
+      }
+
+      logger.info { "${ProjectorServer::class.simpleName} connecting to relay $relayUrl with serverId $serverId" }
+      builders.add(HttpWsClientBuilder("$scheme://$relayUrl", serverId))
+    }
+
+    val host = ProjectorServer.getEnvHost()
+    val port = ProjectorServer.getEnvPort()
+    logger.info { "${ProjectorServer::class.simpleName} is starting on host $host and port $port" }
+
+    val serverBuilder = HttpWsServerBuilder(host, port)
+    serverBuilder.getMainWindows = {
+      ProjectorServer.getMainWindows().map {
+        MainWindow(
+          title = it.title,
+          pngBase64Icon = it.icons
+            ?.firstOrNull()
+            ?.let { imageId -> ProjectorImageCacher.getImage(imageId as ImageId) as? ImageData.PngBase64 }
+            ?.pngBase64,
+        )
+      }
+    }
+
+    builders.add(serverBuilder)
+    return MultiTransportBuilder(builders)
+  }
+
+  private val logger = Logger<WebsocketServer>()
+
+  private const val RELAY_PROPERTY_NAME = "ORG_JETBRAINS_PROJECTOR_SERVER_RELAY_URL"
+  private const val SERVER_ID_PROPERTY_NAME = "ORG_JETBRAINS_PROJECTOR_SERVER_RELAY_SERVER_ID"
+  private const val RELAY_USE_WSS = "ORG_JETBRAINS_PROJECTOR_SERVER_RELAY_USE_WSS"
+}


### PR DESCRIPTION
This allows adding and removing transports at runtime, and allows external transport implementations.
 Additionally, an option to disable the default websocket transport is available.

Linked client PR: [projector-client #81](https://github.com/JetBrains/projector-client/pull/81)