### PR TITLE
Make ProjectorServer.clientEventHandler public

### DIFF
--- a/projector-server/src/main/kotlin/org/jetbrains/projector/server/ProjectorServer.kt
+++ b/projector-server/src/main/kotlin/org/jetbrains/projector/server/ProjectorServer.kt
@@ -155,7 +155,8 @@ class ProjectorServer private constructor(
     }
   }
 
-  private val clientEventHandler : ClientEventHandler = object : ClientEventHandler {
+  @Suppress("MemberVisibilityCanBePrivate")  // used in CWM
+  val clientEventHandler : ClientEventHandler = object : ClientEventHandler {
     override fun onClientConnectionEnded(connection: ClientWrapper) {
       val clientSettings = connection.settings
       val connectionTime = (System.currentTimeMillis() - clientSettings.connectionMillis) / 1000.0


### PR DESCRIPTION
This is used in third-party transports implementation. Forgot about it in the original external transport PR.