### PR TITLE
Fix spamming of exception 'Read access is allowed from inside read-action (or EDT) only'

### DIFF
--- a/projector-server/src/main/kotlin/org/jetbrains/projector/server/idea/CaretInfoUpdater.kt
+++ b/projector-server/src/main/kotlin/org/jetbrains/projector/server/idea/CaretInfoUpdater.kt
@@ -79,7 +79,7 @@ class CaretInfoUpdater(private val onCaretInfoChanged: (ServerCaretInfoChangedEv
       null
     } ?: return null
 
-    return dataContext.getData(CommonDataKeys.EDITOR) as? EditorImpl
+    return readAction { dataContext.getData(CommonDataKeys.EDITOR) } as? EditorImpl
   }
 
   private fun loadCaretInfo(): ServerCaretInfoChangedEvent.CaretInfoChange {


### PR DESCRIPTION
Unlike regular text editors they require getting current editor inside read-action (or EDT)