### PR TITLE
Make agent more similar to Projector AWT

### DIFF
--- a/projector-agent/src/main/kotlin/org/jetbrains/projector/agent/CommandsHandler.kt
+++ b/projector-agent/src/main/kotlin/org/jetbrains/projector/agent/CommandsHandler.kt
@@ -25,33 +25,28 @@
 
 package org.jetbrains.projector.agent
 
+import org.jetbrains.projector.awt.data.AwtImageInfo
+import org.jetbrains.projector.awt.data.AwtPaintType
 import org.jetbrains.projector.awt.image.toList
+import org.jetbrains.projector.awt.service.DrawEventQueue
 import org.jetbrains.projector.awt.service.ImageCacher
-import org.jetbrains.projector.common.misc.Do
-import org.jetbrains.projector.common.protocol.data.*
-import org.jetbrains.projector.common.protocol.data.Point
-import org.jetbrains.projector.common.protocol.toClient.*
-import org.jetbrains.projector.server.core.convert.toClient.toBasicStrokeData
-import org.jetbrains.projector.server.core.convert.toClient.toCommonComposite
-import org.jetbrains.projector.server.core.convert.toClient.toCommonPath
-import org.jetbrains.projector.server.core.convert.toClient.toPoint
-import org.jetbrains.projector.server.util.FontCacher
+import org.jetbrains.projector.util.logging.Logger
 import sun.font.FontDesignMetrics
 import java.awt.*
 import java.awt.font.FontRenderContext
-import java.awt.font.TextAttribute
 import java.awt.geom.AffineTransform
 import java.awt.geom.Rectangle2D
 import java.awt.image.BufferedImage
 import java.awt.image.BufferedImageOp
+import java.awt.image.RenderedImage
 import javax.swing.UIManager
 
 internal object CommandsHandler {
 
   fun isSupportedCommand(commandName: String) = commandName in commandsMap
 
-  fun createServerWindowEvents(methodName: String, args: Array<Any?>, g: GraphicsState): List<ServerWindowEvent> {
-    return commandsMap[methodName]?.invoke(args, g) ?: emptyList()
+  fun createServerWindowEvents(methodName: String, args: Array<Any?>, g: GraphicsState, drawEventQueue: DrawEventQueue) {
+    commandsMap[methodName]?.invoke(args, g, drawEventQueue) ?: logger.error { "Unknown method name: $methodName" }
   }
 
   private fun extractTextAntiAliasingHint(hints: RenderingHints?) = hints?.get(RenderingHints.KEY_TEXT_ANTIALIASING)
@@ -67,39 +62,6 @@ internal object CommandsHandler {
       setTransform(scaleX, shearY, shearX, scaleY, 0.0, 0.0)
     }
 
-  private fun createPaintValue(paint: Paint): PaintValue = with(paint) {
-    when (this) {
-      is Color -> PaintValue.Color(rgb)
-      is MultipleGradientPaint -> PaintValue.Unknown("MultipleGradientPaint, maybe split to Linear and Radial")
-      is TexturePaint -> PaintValue.Unknown("TexturePaint")
-      is GradientPaint -> PaintValue.Gradient(
-        p1 = point1.toPoint(),
-        p2 = point2.toPoint(),
-        argb1 = color1.rgb,
-        argb2 = color2.rgb
-      )
-
-      else -> PaintValue.Unknown(this::class.qualifiedName.toString())
-    }
-  }
-
-  private fun createSetClipEvent(identitySpaceClip: Shape?): ServerWindowStateEvent = ServerSetClipEvent(
-    with(identitySpaceClip) {
-      when (this) {
-        null -> null
-        is Rectangle2D -> CommonRectangle(x, y, width, height)
-        else -> this.toCommonPath()
-      }
-    }
-  )
-
-  private fun createSetStrokeDataEvent(stroke: Stroke): ServerWindowStateEvent = with(stroke) {
-    when (this) {
-      is BasicStroke -> ServerSetStrokeEvent(this.toBasicStrokeData())
-      else -> ServerSetUnknownStrokeEvent(this::class.qualifiedName.toString())
-    }
-  }
-
   private fun extractFontRenderingContextFromGraphicsState(g: GraphicsState): FontRenderContext {
     return FontRenderContext(
       g.transform.withoutTranslation,
@@ -108,114 +70,132 @@ internal object CommandsHandler {
     )
   }
 
-  private fun convertToServerWindowEvent(
-    paintEvent: ServerWindowPaintEvent,
-    g: GraphicsState,
-  ): List<ServerWindowEvent> = Do exhaustive when (paintEvent) {
-    is ServerWindowToDoPaintEvent -> listOf(paintEvent)
-
-    is ServerPaintOvalEvent,
-    is ServerPaintRoundRectEvent,
-    is ServerPaintRectEvent,
-    is ServerDrawLineEvent,
-    is ServerDrawPolylineEvent,
-    is ServerPaintPolygonEvent,
-    is ServerPaintPathEvent,
-    -> listOf(
-      createSetClipEvent(g.clip),
-      ServerSetTransformEvent(tx = g.transform.toList()),
-      createSetStrokeDataEvent(g.stroke),
-      ServerSetPaintEvent(createPaintValue(g.paint)),
-      ServerSetCompositeEvent(g.composite.toCommonComposite()),
-      paintEvent
-    )
-
-    is ServerDrawImageEvent,
-    is ServerCopyAreaEvent,
-    -> listOf(
-      createSetClipEvent(g.clip),
-      ServerSetTransformEvent(tx = g.transform.toList()),
-      ServerSetCompositeEvent(g.composite.toCommonComposite()),
-      paintEvent
-    )
-
-    is ServerDrawStringEvent -> listOf(
-      createSetClipEvent(g.clip),
-      ServerSetTransformEvent(tx = g.transform.toList()),
-      g.font.let {
-        ServerSetFontEvent(
-          fontId = FontCacher.getId(it),
-          fontSize = it.size,
-          ligaturesOn = ((it.attributes[TextAttribute.LIGATURES] as Int?) ?: 0) > 0,
-        )
-      },
-      ServerSetPaintEvent(createPaintValue(g.paint)),
-      ServerSetCompositeEvent(g.composite.toCommonComposite()),
-      paintEvent
-    )
+  private inline fun paintPlain(drawEventQueue: DrawEventQueue, crossinline command: DrawEventQueue.CommandBuilder.() -> Unit) {
+    drawEventQueue.buildCommand().command()
   }
 
-  private fun paintRectCommand(
-    paintType: PaintType,
+  private inline fun paintShape(
+    g: GraphicsState,
+    drawEventQueue: DrawEventQueue,
+    crossinline command: DrawEventQueue.CommandBuilder.() -> Unit,
+  ) {
+    drawEventQueue
+      .buildCommand()
+      .setClip(identitySpaceClip = g.clip)
+      .setTransform(g.transform.toList())
+      .setStroke(g.stroke)
+      .setPaint(g.paint)
+      .setComposite(g.composite)
+      .command()
+  }
+
+  private inline fun paintArea(
+    g: GraphicsState,
+    drawEventQueue: DrawEventQueue,
+    crossinline command: DrawEventQueue.CommandBuilder.() -> Unit,
+  ) {
+    drawEventQueue
+      .buildCommand()
+      .setClip(identitySpaceClip = g.clip)
+      .setTransform(g.transform.toList())
+      .setComposite(g.composite)
+      .command()
+  }
+
+  private fun paintString(str: String, x: Double, y: Double, g: GraphicsState, drawEventQueue: DrawEventQueue) {
+    if (str.isBlank()) {
+      return
+    }
+
+    val metrics = FontDesignMetrics.getMetrics(g.font, extractFontRenderingContextFromGraphicsState(g))
+    val desiredWidth = metrics.stringWidth(str)
+
+    drawEventQueue
+      .buildCommand()
+      .setClip(identitySpaceClip = g.clip)
+      .setTransform(g.transform.toList())
+      .setFont(g.font)
+      .setPaint(g.paint)
+      .setComposite(g.composite)
+      .drawString(str, x = x, y = y, desiredWidth = desiredWidth.toDouble())
+  }
+
+  private fun addPaintRectCommand(
+    paintType: AwtPaintType,
     x: Double,
     y: Double,
     width: Double,
     height: Double,
-    g: GraphicsState,
-  ): List<ServerWindowEvent> {
-    val event = ServerPaintRectEvent(paintType, x, y, width, height)
-    return convertToServerWindowEvent(event, g)
-  }
+    graphicsState: GraphicsState,
+    drawEventQueue: DrawEventQueue,
+  ) {
+    if (width <= 0 || height <= 0) {
+      return
+    }
 
-  private fun paintShape(paintType: PaintType, shape: Shape, g: GraphicsState): List<ServerWindowEvent> {
-    return when (shape) {
-      is Rectangle2D -> paintRectCommand(paintType, shape.x, shape.y, shape.width, shape.height, g)
-
-      else -> convertToServerWindowEvent(ServerPaintPathEvent(paintType, shape.toCommonPath()), g)
+    paintShape(graphicsState, drawEventQueue) {
+      paintRect(
+        paintType = paintType,
+        x = x,
+        y = y,
+        width = width,
+        height = height
+      )
     }
   }
 
-  private fun draw(args: Array<Any?>, graphicsState: GraphicsState): List<ServerWindowEvent> {
-    return paintShape(paintType = PaintType.DRAW, shape = args[0] as Shape, g = graphicsState)
+  private fun paintShape(paintType: AwtPaintType, shape: Shape, g: GraphicsState, drawEventQueue: DrawEventQueue) {
+    when (shape) {
+      is Rectangle2D -> addPaintRectCommand(paintType, shape.x, shape.y, shape.width, shape.height, g, drawEventQueue)
+
+      else -> paintShape(g, drawEventQueue) { paintPath(paintType, shape) }
+    }
+  }
+
+  private fun draw(args: Array<Any?>, graphicsState: GraphicsState, drawEventQueue: DrawEventQueue) {
+    paintShape(paintType = AwtPaintType.DRAW, shape = args[0] as Shape, g = graphicsState, drawEventQueue = drawEventQueue)
+  }
+
+  private fun drawRenderedImage(args: Array<Any?>, graphicsState: GraphicsState, drawEventQueue: DrawEventQueue) {
+    val img = args[0] as RenderedImage
+    val xform = args[1] as AffineTransform?
+
+    // xform nullability is required for compatibility, so provide a default (identity) transformation
+    val xFormOrDefault = xform ?: AffineTransform()
+
+    // Currently only BufferedImage is supported
+    when (img) {
+      is BufferedImage -> {
+        val info = AwtImageInfo.Transformation(xFormOrDefault.toList())
+        extractImage(img, info, "drawRenderedImage(img, xform)", graphicsState, drawEventQueue)
+      }
+      else -> paintPlain(drawEventQueue) { drawRenderedImage() }
+    }
   }
 
   @Suppress("UNUSED_PARAMETER")  // todo: use parameter
-  private fun drawRenderedImage(args: Array<Any?>, graphicsState: GraphicsState): List<ServerWindowEvent> {
-    return convertToServerWindowEvent(paintEvent = ServerDrawRenderedImageEvent, g = graphicsState)
+  private fun drawRenderableImage(args: Array<Any?>, graphicsState: GraphicsState, drawEventQueue: DrawEventQueue) {
+    paintPlain(drawEventQueue) { drawRenderableImage() }
   }
 
-  @Suppress("UNUSED_PARAMETER")  // todo: use parameter
-  private fun drawRenderableImage(args: Array<Any?>, graphicsState: GraphicsState): List<ServerWindowEvent> {
-    return convertToServerWindowEvent(paintEvent = ServerDrawRenderableImageEvent, g = graphicsState)
+  private fun drawString(args: Array<Any?>, graphicsState: GraphicsState, drawEventQueue: DrawEventQueue) {
+    val str = args[0] as String
+    val x = args[1].asDouble()
+    val y = args[2].asDouble()
+    paintString(str, x = x, y = y, graphicsState, drawEventQueue)
   }
 
-  private fun drawString(str: String, x: Double, y: Double, g: GraphicsState): List<ServerWindowEvent> {
-    val metrics = FontDesignMetrics.getMetrics(g.font, extractFontRenderingContextFromGraphicsState(g))
-    val desiredWidth = metrics.stringWidth(str)
-    val event = ServerDrawStringEvent(str = str, x = x, y = y, desiredWidth = desiredWidth.toDouble())
-    return convertToServerWindowEvent(paintEvent = event, g = g)
+  private fun drawStringSII(args: Array<Any?>, graphicsState: GraphicsState, drawEventQueue: DrawEventQueue) {
+    drawString(args, graphicsState, drawEventQueue)
   }
 
-  private fun drawStringSII(args: Array<Any?>, graphicsState: GraphicsState): List<ServerWindowEvent> {
-    return drawString(
-      str = args[0] as String,
-      x = args[1].asDouble(),
-      y = args[2].asDouble(),
-      g = graphicsState
-    )
+  private fun drawStringSFF(args: Array<Any?>, graphicsState: GraphicsState, drawEventQueue: DrawEventQueue) {
+    drawString(args, graphicsState, drawEventQueue)
   }
 
-  private fun drawStringSFF(args: Array<Any?>, graphicsState: GraphicsState): List<ServerWindowEvent> {
-    return drawString(
-      str = args[0] as String,
-      x = args[1].asDouble(),
-      y = args[2].asDouble(),
-      g = graphicsState
-    )
-  }
-
-  private fun drawChars(args: Array<Any?>, graphicsState: GraphicsState): List<ServerWindowEvent> {
-    return drawString(
+  // Took from java.awt.Graphics.drawChars
+  private fun drawChars(args: Array<Any?>, graphicsState: GraphicsState, drawEventQueue: DrawEventQueue) {
+    paintString(
       str = String(
         chars = args[0] as CharArray,
         offset = args[1] as Int,
@@ -223,284 +203,411 @@ internal object CommandsHandler {
       ),
       x = args[3].asDouble(),
       y = args[4].asDouble(),
-      g = graphicsState
+      g = graphicsState,
+      drawEventQueue,
     )
   }
 
-  private fun fill(args: Array<Any?>, graphicsState: GraphicsState): List<ServerWindowEvent> {
-    return paintShape(paintType = PaintType.FILL, shape = args[0] as Shape, g = graphicsState)
+  private fun fill(args: Array<Any?>, graphicsState: GraphicsState, drawEventQueue: DrawEventQueue) {
+    paintShape(paintType = AwtPaintType.FILL, shape = args[0] as Shape, g = graphicsState, drawEventQueue)
   }
 
-  private fun copyArea(args: Array<Any?>, graphicsState: GraphicsState): List<ServerWindowEvent> {
-    return convertToServerWindowEvent(
-      paintEvent = ServerCopyAreaEvent(
-        x = args[0] as Int,
-        y = args[1] as Int,
-        width = args[2] as Int,
-        height = args[3] as Int,
-        dx = args[4] as Int,
-        dy = args[5] as Int
-      ),
-      g = graphicsState)
+  private fun copyArea(args: Array<Any?>, graphicsState: GraphicsState, drawEventQueue: DrawEventQueue) {
+    val x = args[0] as Int
+    val y = args[1] as Int
+    val width = args[2] as Int
+    val height = args[3] as Int
+    val dx = args[4] as Int
+    val dy = args[5] as Int
+
+    paintArea(graphicsState, drawEventQueue) {
+      copyArea(
+        x = x,
+        y = y,
+        width = width,
+        height = height,
+        dx = dx,
+        dy = dy
+      )
+    }
   }
 
-  private fun drawLine(x1: Int, y1: Int, x2: Int, y2: Int, g: GraphicsState): List<ServerWindowEvent> {
-    val event = ServerDrawLineEvent(x1, y1, x2, y2)
-    return convertToServerWindowEvent(event, g)
+  private fun drawLine(x1: Int, y1: Int, x2: Int, y2: Int, g: GraphicsState, drawEventQueue: DrawEventQueue) {
+    paintShape(g, drawEventQueue) {
+      drawLine(
+        x1 = x1,
+        y1 = y1,
+        x2 = x2,
+        y2 = y2
+      )
+    }
   }
 
-  private fun drawLine(args: Array<Any?>, graphicsState: GraphicsState): List<ServerWindowEvent> {
-    return drawLine(
+  private fun drawLine(args: Array<Any?>, graphicsState: GraphicsState, drawEventQueue: DrawEventQueue) {
+    drawLine(
       x1 = args[0] as Int,
       y1 = args[1] as Int,
       x2 = args[2] as Int,
       y2 = args[3] as Int,
-      g = graphicsState
+      g = graphicsState,
+      drawEventQueue,
     )
   }
 
   // Took from java.awt.Graphics.drawRect
-  private fun drawRect(args: Array<Any?>, graphicsState: GraphicsState): List<ServerWindowEvent> {
+  private fun drawRect(args: Array<Any?>, g: GraphicsState, drawEventQueue: DrawEventQueue) {
     val x: Int = args[0] as Int
     val y: Int = args[1] as Int
     val width: Int = args[2] as Int
     val height: Int = args[3] as Int
-    val g = graphicsState
 
     if (width < 0 || height < 0) {
-      return emptyList()
+      return
     }
-
-    val events = ArrayList<ServerWindowEvent>()
 
     if (height == 0 || width == 0) {
-      drawLine(x, y, x + width, y + height, g).run(events::addAll)
+      drawLine(x, y, x + width, y + height, g, drawEventQueue)
     }
     else {
-      drawLine(x, y, x + width - 1, y, g).run(events::addAll)
-      drawLine(x + width, y, x + width, y + height - 1, g).run(events::addAll)
-      drawLine(x + width, y + height, x + 1, y + height, g).run(events::addAll)
-      drawLine(x, y + height, x, y + 1, g).run(events::addAll)
+      drawLine(x, y, x + width - 1, y, g, drawEventQueue)
+      drawLine(x + width, y, x + width, y + height - 1, g, drawEventQueue)
+      drawLine(x + width, y + height, x + 1, y + height, g, drawEventQueue)
+      drawLine(x, y + height, x, y + 1, g, drawEventQueue)
+    }
+  }
+
+  private fun fillRect(args: Array<Any?>, graphicsState: GraphicsState, drawEventQueue: DrawEventQueue) {
+    val x = args[0].asDouble()
+    val y = args[1].asDouble()
+    val width = args[2].asDouble()
+    val height = args[3].asDouble()
+
+    addPaintRectCommand(AwtPaintType.FILL, x, y, width, height, graphicsState, drawEventQueue)
+  }
+
+  private fun clearRect(args: Array<Any?>, graphicsState: GraphicsState, drawEventQueue: DrawEventQueue) {
+    val x = args[0].asDouble()
+    val y = args[1].asDouble()
+    val width = args[2].asDouble()
+    val height = args[3].asDouble()
+    addPaintRectCommand(
+      AwtPaintType.FILL, x, y, width, height,
+      graphicsState.copy(composite = AlphaComposite.Src, paint = graphicsState.background), drawEventQueue,
+    )
+  }
+
+  private fun paintRoundRect(
+    paintType: AwtPaintType,
+    x: Int,
+    y: Int,
+    width: Int,
+    height: Int,
+    arcWidth: Int,
+    arcHeight: Int,
+    graphicsState: GraphicsState,
+    drawEventQueue: DrawEventQueue,
+  ) {
+    if (width <= 0 || height <= 0) {
+      return
     }
 
-    return events
+    paintShape(graphicsState, drawEventQueue) {
+      paintRoundRect(
+        paintType = paintType,
+        x = x,
+        y = y,
+        width = width,
+        height = height,
+        arcWidth = arcWidth,
+        arcHeight = arcHeight
+      )
+    }
   }
 
-  private fun fillRect(args: Array<Any?>, graphicsState: GraphicsState): List<ServerWindowEvent> {
-    return paintRectCommand(
-      paintType = PaintType.FILL,
-      x = args[0].asDouble(),
-      y = args[1].asDouble(),
-      width = args[2].asDouble(),
-      height = args[3].asDouble(),
-      g = graphicsState
+  private fun drawRoundRect(args: Array<Any?>, graphicsState: GraphicsState, drawEventQueue: DrawEventQueue) {
+    val x = args[0] as Int
+    val y = args[1] as Int
+    val width = args[2] as Int
+    val height = args[3] as Int
+    val arcWidth = args[4] as Int
+    val arcHeight = args[5] as Int
+
+    paintRoundRect(
+      paintType = AwtPaintType.DRAW,
+      x = x,
+      y = y,
+      width = width,
+      height = height,
+      arcWidth = arcWidth,
+      arcHeight = arcHeight,
+      graphicsState,
+      drawEventQueue,
     )
   }
 
-  private fun clearRect(args: Array<Any?>, graphicsState: GraphicsState): List<ServerWindowEvent> {
-    return paintRectCommand(
-      paintType = PaintType.FILL,
-      x = args[0].asDouble(),
-      y = args[1].asDouble(),
-      width = args[2].asDouble(),
-      height = args[3].asDouble(),
-      g = graphicsState.copy(composite = AlphaComposite.Src, paint = graphicsState.background)
+  private fun fillRoundRect(args: Array<Any?>, graphicsState: GraphicsState, drawEventQueue: DrawEventQueue) {
+    val x = args[0] as Int
+    val y = args[1] as Int
+    val width = args[2] as Int
+    val height = args[3] as Int
+    val arcWidth = args[4] as Int
+    val arcHeight = args[5] as Int
+
+    paintRoundRect(
+      paintType = AwtPaintType.FILL,
+      x = x,
+      y = y,
+      width = width,
+      height = height,
+      arcWidth = arcWidth,
+      arcHeight = arcHeight,
+      graphicsState,
+      drawEventQueue,
     )
   }
 
-  private fun drawRoundRect(args: Array<Any?>, graphicsState: GraphicsState): List<ServerWindowEvent> {
-    return convertToServerWindowEvent(
-      ServerPaintRoundRectEvent(
-        paintType = PaintType.DRAW,
-        x = args[0] as Int,
-        y = args[1] as Int,
-        width = args[2] as Int,
-        height = args[3] as Int,
-        arcWidth = args[4] as Int,
-        arcHeight = args[5] as Int
-      ),
-      graphicsState
+  private fun paintOval(
+    paintType: AwtPaintType,
+    x: Int,
+    y: Int,
+    width: Int,
+    height: Int,
+    graphicsState: GraphicsState,
+    drawEventQueue: DrawEventQueue,
+  ) {
+    if (width <= 0 || height <= 0) {
+      return
+    }
+
+    paintShape(graphicsState, drawEventQueue) {
+      paintOval(
+        paintType = paintType,
+        x = x,
+        y = y,
+        width = width,
+        height = height
+      )
+    }
+  }
+
+  private fun drawOval(args: Array<Any?>, graphicsState: GraphicsState, drawEventQueue: DrawEventQueue) {
+    val x = args[0] as Int
+    val y = args[1] as Int
+    val width = args[2] as Int
+    val height = args[3] as Int
+
+    paintOval(
+      paintType = AwtPaintType.DRAW,
+      x = x,
+      y = y,
+      width = width,
+      height = height,
+      graphicsState,
+      drawEventQueue,
     )
   }
 
-  private fun fillRoundRect(args: Array<Any?>, graphicsState: GraphicsState): List<ServerWindowEvent> {
-    val event = ServerPaintRoundRectEvent(
-      paintType = PaintType.FILL,
-      x = args[0] as Int,
-      y = args[1] as Int,
-      width = args[2] as Int,
-      height = args[3] as Int,
-      arcWidth = args[4] as Int,
-      arcHeight = args[5] as Int
-    )
+  private fun fillOval(args: Array<Any?>, graphicsState: GraphicsState, drawEventQueue: DrawEventQueue) {
+    val x = args[0] as Int
+    val y = args[1] as Int
+    val width = args[2] as Int
+    val height = args[3] as Int
 
-    return convertToServerWindowEvent(event, graphicsState)
-  }
-
-  private fun drawOval(args: Array<Any?>, graphicsState: GraphicsState): List<ServerWindowEvent> {
-
-    return convertToServerWindowEvent(
-      paintEvent = ServerPaintOvalEvent(
-        paintType = PaintType.DRAW,
-        x = args[0] as Int,
-        y = args[1] as Int,
-        width = args[2] as Int,
-        height = args[3] as Int
-      ),
-      g = graphicsState
+    paintOval(
+      paintType = AwtPaintType.FILL,
+      x = x,
+      y = y,
+      width = width,
+      height = height,
+      graphicsState,
+      drawEventQueue,
     )
   }
 
-  private fun fillOval(args: Array<Any?>, graphicsState: GraphicsState): List<ServerWindowEvent> {
-    return convertToServerWindowEvent(
-      paintEvent = ServerPaintOvalEvent(
-        paintType = PaintType.FILL,
-        x = args[0] as Int,
-        y = args[1] as Int,
-        width = args[2] as Int,
-        height = args[3] as Int
-      ),
-      g = graphicsState
+  private fun paintArc(
+    paintType: AwtPaintType,
+    x: Int,
+    y: Int,
+    width: Int,
+    height: Int,
+    startAngle: Int,
+    arcAngle: Int,
+    graphicsState: GraphicsState,
+    drawEventQueue: DrawEventQueue,
+  ) {
+    if (width <= 0 || height <= 0) {
+      return
+    }
+
+    paintShape(graphicsState, drawEventQueue) {
+      paintArc(
+        paintType = paintType,
+        x = x,
+        y = y,
+        width = width,
+        height = height,
+        startAngle = startAngle,
+        arcAngle = arcAngle
+      )
+    }
+  }
+
+  private fun drawArc(args: Array<Any?>, graphicsState: GraphicsState, drawEventQueue: DrawEventQueue) {
+    val x = args[0] as Int
+    val y = args[1] as Int
+    val width = args[2] as Int
+    val height = args[3] as Int
+    val startAngle = args[4] as Int
+    val arcAngle = args[5] as Int
+
+    paintArc(
+      paintType = AwtPaintType.DRAW,
+      x = x,
+      y = y,
+      width = width,
+      height = height,
+      startAngle = startAngle,
+      arcAngle = arcAngle,
+      graphicsState,
+      drawEventQueue,
     )
   }
 
-  private fun drawArc(args: Array<Any?>, graphicsState: GraphicsState): List<ServerWindowEvent> {
-    return convertToServerWindowEvent(
-      paintEvent = ServerPaintArcEvent(
-        paintType = PaintType.DRAW,
-        x = args[0] as Int,
-        y = args[1] as Int,
-        width = args[2] as Int,
-        height = args[3] as Int,
-        startAngle = args[4] as Int,
-        arcAngle = args[5] as Int
-      ),
-      g = graphicsState
+  private fun fillArc(args: Array<Any?>, graphicsState: GraphicsState, drawEventQueue: DrawEventQueue) {
+    val x = args[0] as Int
+    val y = args[1] as Int
+    val width = args[2] as Int
+    val height = args[3] as Int
+    val startAngle = args[4] as Int
+    val arcAngle = args[5] as Int
+
+    paintArc(
+      paintType = AwtPaintType.FILL,
+      x = x,
+      y = y,
+      width = width,
+      height = height,
+      startAngle = startAngle,
+      arcAngle = arcAngle,
+      graphicsState,
+      drawEventQueue,
     )
   }
 
-  private fun fillArc(args: Array<Any?>, graphicsState: GraphicsState): List<ServerWindowEvent> {
-    return convertToServerWindowEvent(
-      paintEvent = ServerPaintArcEvent(
-        paintType = PaintType.FILL,
-        x = args[0] as Int,
-        y = args[1] as Int,
-        width = args[2] as Int,
-        height = args[3] as Int,
-        startAngle = args[4] as Int,
-        arcAngle = args[5] as Int
-      ),
-      g = graphicsState
-    )
-  }
-
-  private fun drawPolyline(args: Array<Any?>, graphicsState: GraphicsState): List<ServerWindowEvent> {
+  private fun drawPolyline(args: Array<Any?>, graphicsState: GraphicsState, drawEventQueue: DrawEventQueue) {
     val xPoints = args[0] as IntArray
     val yPoints = args[1] as IntArray
     val nPoints = args[2] as Int
 
-    val event = ServerDrawPolylineEvent(
-      xPoints.take(nPoints).zip(yPoints.take(nPoints)) { x, y -> Point(x.toDouble(), y.toDouble()) }
-    )
-    return convertToServerWindowEvent(event, graphicsState)
+    if (nPoints <= 0) {
+      return
+    }
+
+    paintShape(graphicsState, drawEventQueue) { drawPolyline(xPoints.take(nPoints).zip(yPoints.take(nPoints))) }
   }
 
   private fun paintPolygon(
-    paintType: PaintType,
+    paintType: AwtPaintType,
     xPoints: IntArray,
     yPoints: IntArray,
     nPoints: Int,
     g: GraphicsState,
-  ): List<ServerWindowEvent> {
-    val event = ServerPaintPolygonEvent(
-      paintType,
-      xPoints.take(nPoints).zip(yPoints.take(nPoints)) { x, y -> Point(x.toDouble(), y.toDouble()) }
-    )
-    return convertToServerWindowEvent(event, g)
-  }
-
-  private fun drawPolygon(args: Array<Any?>, graphicsState: GraphicsState): List<ServerWindowEvent> {
-    return paintPolygon(
-      paintType = PaintType.DRAW,
-      xPoints = args[0] as IntArray,
-      yPoints = args[1] as IntArray,
-      nPoints = args[2] as Int,
-      g = graphicsState
-    )
-  }
-
-  private fun fillPolygon(args: Array<Any?>, graphicsState: GraphicsState): List<ServerWindowEvent> {
-    return paintPolygon(
-      paintType = PaintType.FILL,
-      xPoints = args[0] as IntArray,
-      yPoints = args[1] as IntArray,
-      nPoints = args[2] as Int,
-      g = graphicsState
-    )
-  }
-
-  private fun extractImage(img: Image?, imageEventInfo: ImageEventInfo, methodName: String, g: GraphicsState): List<ServerWindowEvent> {
-    if (img == null) {
-      return emptyList()
+    drawEventQueue: DrawEventQueue,
+  ) {
+    if (nPoints <= 0) {
+      return
     }
 
-    return convertToServerWindowEvent(
-      ServerDrawImageEvent(imageId = ImageCacher.instance.getImageId(img, methodName) as ImageId, imageEventInfo = imageEventInfo), g)
+    paintShape(g, drawEventQueue) {
+      paintPolygon(
+        paintType = paintType,
+        points = xPoints.take(nPoints).zip(yPoints.take(nPoints))
+      )
+    }
   }
 
-  private fun drawImage0(args: Array<Any?>, graphicsState: GraphicsState): List<ServerWindowEvent> {
-    return extractImage(
+  private fun drawPolygon(args: Array<Any?>, graphicsState: GraphicsState, drawEventQueue: DrawEventQueue) {
+    val xPoints = args[0] as IntArray
+    val yPoints = args[1] as IntArray
+    val nPoints = args[2] as Int
+
+    paintPolygon(AwtPaintType.DRAW, xPoints, yPoints, nPoints, graphicsState, drawEventQueue)
+  }
+
+  private fun fillPolygon(args: Array<Any?>, graphicsState: GraphicsState, drawEventQueue: DrawEventQueue) {
+    val xPoints = args[0] as IntArray
+    val yPoints = args[1] as IntArray
+    val nPoints = args[2] as Int
+
+    paintPolygon(AwtPaintType.FILL, xPoints, yPoints, nPoints, graphicsState, drawEventQueue)
+  }
+
+  private fun extractImage(img: Image?, awtImageInfo: AwtImageInfo, methodName: String, g: GraphicsState, drawEventQueue: DrawEventQueue) {
+    if (img == null) {
+      return
+    }
+
+    paintArea(g, drawEventQueue) { drawImage(imageId = ImageCacher.instance.getImageId(img, methodName), awtImageInfo = awtImageInfo) }
+  }
+
+  private fun drawImage0(args: Array<Any?>, graphicsState: GraphicsState, drawEventQueue: DrawEventQueue) {
+    extractImage(
       img = args[0] as Image?,
-      imageEventInfo = ImageEventInfo.Transformed((args[1] as AffineTransform).toList()),
+      awtImageInfo = AwtImageInfo.Transformation((args[1] as AffineTransform).toList()),
       methodName = "drawImage(img, xform, obs)",
-      g = graphicsState
+      g = graphicsState,
+      drawEventQueue,
     )
   }
 
-  private fun drawImage1(args: Array<Any?>, graphicsState: GraphicsState): List<ServerWindowEvent> {
+  private fun drawImage1(args: Array<Any?>, graphicsState: GraphicsState, drawEventQueue: DrawEventQueue) {
+    val img = args[0] as BufferedImage? ?: return
 
-    return extractImage(
-      img = (args[1] as BufferedImageOp).filter(args[0] as BufferedImage? ?: return emptyList(), null),
-      imageEventInfo = AffineTransform(1.0, 0.0, 0.0, 1.0, args[2].asDouble(), args[3].asDouble())
+    extractImage(
+      img = (args[1] as BufferedImageOp).filter(img, null),
+      awtImageInfo = AffineTransform(1.0, 0.0, 0.0, 1.0, args[2].asDouble(), args[3].asDouble())
         .toList()
-        .run(ImageEventInfo::Transformed),
+        .let(AwtImageInfo::Transformation),
       methodName = "drawImage(img, xform, obs)",
-      g = graphicsState
+      g = graphicsState,
+      drawEventQueue,
     )
   }
 
-  private fun drawImage2(args: Array<Any?>, graphicsState: GraphicsState): List<ServerWindowEvent> {
-    return extractImage(
+  private fun drawImage2(args: Array<Any?>, graphicsState: GraphicsState, drawEventQueue: DrawEventQueue) {
+    extractImage(
       img = args[0] as Image?,
-      imageEventInfo = ImageEventInfo.Xy(
+      awtImageInfo = AwtImageInfo.Point(
         x = args[1] as Int,
         y = args[2] as Int,
-        argbBackgroundColor = (args[3] as Color?)?.rgb),
+        argbBackgroundColor = (args[3] as Color?)?.rgb,
+      ),
       methodName = "drawImage(img, x, y, bgcolor, observer)",
-      g = graphicsState
+      g = graphicsState,
+      drawEventQueue,
     )
   }
 
-  private fun drawImage3(args: Array<Any?>, graphicsState: GraphicsState): List<ServerWindowEvent> {
-
-    return extractImage(
+  private fun drawImage3(args: Array<Any?>, graphicsState: GraphicsState, drawEventQueue: DrawEventQueue) {
+    extractImage(
       img = args[0] as Image?,
-      imageEventInfo = ImageEventInfo.XyWh(
+      awtImageInfo = AwtImageInfo.Rectangle(
         x = args[1] as Int,
         y = args[2] as Int,
         width = args[3] as Int,
         height = args[4] as Int,
-        argbBackgroundColor = (args[5] as Color?)?.rgb
+        argbBackgroundColor = (args[5] as Color?)?.rgb,
       ),
       methodName = "drawImage(img, x, y, w, h, bgcolor, observer)",
-      g = graphicsState
+      g = graphicsState,
+      drawEventQueue,
     )
   }
 
-  private fun drawImage4(args: Array<Any?>, graphicsState: GraphicsState): List<ServerWindowEvent> {
-    return extractImage(
+  private fun drawImage4(args: Array<Any?>, graphicsState: GraphicsState, drawEventQueue: DrawEventQueue) {
+    extractImage(
       img = args[0] as Image?,
-      imageEventInfo = ImageEventInfo.Ds(
+      awtImageInfo = AwtImageInfo.Area(
         dx1 = args[1] as Int,
         dy1 = args[2] as Int,
         dx2 = args[3] as Int,
@@ -509,14 +616,15 @@ internal object CommandsHandler {
         sy1 = args[6] as Int,
         sx2 = args[7] as Int,
         sy2 = args[8] as Int,
-        argbBackgroundColor = (args[9] as Color?)?.rgb
+        argbBackgroundColor = (args[9] as Color?)?.rgb,
       ),
       methodName = "drawImage(img, d..., s..., bgcolor, observer)",
-      g = graphicsState
+      g = graphicsState,
+      drawEventQueue,
     )
   }
 
-  private val commandsMap: Map<String, (Array<Any?>, GraphicsState) -> List<ServerWindowEvent>> = mapOf(
+  private val commandsMap: Map<String, (Array<Any?>, GraphicsState, DrawEventQueue) -> Unit> = mapOf(
     "sun.java2d.SunGraphics2D.draw(java.awt.Shape)" to CommandsHandler::draw,
     "sun.java2d.SunGraphics2D.drawRenderedImage(java.awt.image.RenderedImage,java.awt.geom.AffineTransform)" to CommandsHandler::drawRenderedImage,
     "sun.java2d.SunGraphics2D.drawRenderableImage(java.awt.image.renderable.RenderableImage,java.awt.geom.AffineTransform)" to CommandsHandler::drawRenderableImage,
@@ -546,4 +654,6 @@ internal object CommandsHandler {
   )
 
   private fun Any?.asDouble(): Double = (this as Number).toDouble()
+
+  private val logger = Logger<CommandsHandler>()
 }


### PR DESCRIPTION
This is a prerequisite for PRJ-20 fix (in `prj-20` branches). I've decided to extract it separately for review convenience. Guys, please take a look, mostly for being aware of these changes (but of course review comments will be appreciated).

In the future, agent and headless rendering logic can be even more unified and duplicated code can be removed; tests can be added. However, we don't have time for this further refactoring now so I only added this idea to my TODO list.