### PR TITLE
PRJ-60 Fix incorrect popup detection

### DIFF
--- a/projector-server/CHANGELOG.md
+++ b/projector-server/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Support mono fonts without "mono" in their names (useful when building Projector with fonts other than JB Mono)
 - PRJ-443 Remove "Allow popups for this site" alert when allowance is not needed
 - PRJ-770 Update GotIt message position if widget is moved
+- PRJ-60 Not pixel perfect popups position
 
 ## Changed
 

--- a/projector-server/src/main/kotlin/org/jetbrains/projector/server/util/Convert.kt
+++ b/projector-server/src/main/kotlin/org/jetbrains/projector/server/util/Convert.kt
@@ -33,7 +33,7 @@ import org.jetbrains.projector.common.protocol.data.ImageEventInfo
 import org.jetbrains.projector.common.protocol.data.PaintType
 import org.jetbrains.projector.common.protocol.toClient.WindowType
 import org.jetbrains.projector.common.protocol.toServer.ResizeDirection
-import javax.swing.Popup
+import java.awt.Window
 
 fun AwtPaintType.toPaintType() = when (this) {
   AwtPaintType.DRAW -> PaintType.DRAW
@@ -54,7 +54,7 @@ fun AwtImageInfo.toImageEventInfo() = when (this) {
 val PWindow.windowType: WindowType
   get() = when {
     "IdeFrameImpl" in target::class.java.simpleName -> WindowType.IDEA_WINDOW
-    target is Popup -> WindowType.POPUP
+    target.let { it is Window && it.type == Window.Type.POPUP } -> WindowType.POPUP
     else -> WindowType.WINDOW
   }
 


### PR DESCRIPTION
Thanks for noticing that place!

I've corrected it and now popups are pixel-perfect for me:

![image](https://user-images.githubusercontent.com/20105593/143913521-c30e2612-803e-49f1-85bb-32bc29b9b812.png)

Before (from [PRJ-60](https://youtrack.jetbrains.com/issue/PRJ-60)):

![image](https://user-images.githubusercontent.com/20105593/143913623-fe5e115e-a645-4f2d-80a9-cb35b842985f.png)
