### PR TITLE
Use WINDOW_GAINED_FOCUS event instead of requesting focus on window component

### DIFF
--- a/projector-awt/src/main/kotlin/org/jetbrains/projector/awt/PWindow.kt
+++ b/projector-awt/src/main/kotlin/org/jetbrains/projector/awt/PWindow.kt
@@ -35,6 +35,7 @@ import org.jetbrains.projector.util.logging.Logger
 import sun.awt.AWTAccessor
 import java.awt.*
 import java.awt.event.ComponentEvent
+import java.awt.event.WindowEvent
 import java.awt.peer.ComponentPeer
 import java.lang.ref.WeakReference
 import java.util.*
@@ -131,7 +132,13 @@ class PWindow private constructor(val target: Component, private val isAgent: Bo
     if (!hasMoved && !hasResized) return
 
     toFront()
-    target.requestFocusInWindow()
+    // focus is handled in if(isAgent) branches in `move` and `resize`
+    if (!isAgent) {
+      if (target is Window)
+        Toolkit.getDefaultToolkit().systemEventQueue.postEvent(WindowEvent(target, WindowEvent.WINDOW_GAINED_FOCUS))
+      else // TODO: double-check this focus request is necessary for non-Window heavyweight components
+        target.requestFocusInWindow()
+    }
 
     if (PGraphicsEnvironment.clientDoesWindowManagement) {
       AWTAccessor.getComponentAccessor().setLocation(target, x, y)

--- a/projector-awt/src/main/kotlin/org/jetbrains/projector/awt/PWindow.kt
+++ b/projector-awt/src/main/kotlin/org/jetbrains/projector/awt/PWindow.kt
@@ -125,20 +125,24 @@ class PWindow private constructor(val target: Component, private val isAgent: Bo
     updateGraphics()
   }
 
+  fun transferNativeFocus() {
+    toFront()
+    if (!isAgent) {
+      if (target is Window)
+        Toolkit.getDefaultToolkit().systemEventQueue.postEvent(WindowEvent(target, WindowEvent.WINDOW_GAINED_FOCUS))
+      else // TODO: double-check this focus request is necessary for non-Window heavyweight components
+        target.requestFocusInWindow()
+    } else
+      target.requestFocusInWindow()
+  }
+
   fun setBounds(x: Int, y: Int, width: Int, height: Int) {
     val hasMoved = target.x != x || target.y != y
     val hasResized = target.width != width || target.height != height
 
     if (!hasMoved && !hasResized) return
 
-    toFront()
-    // focus is handled in if(isAgent) branches in `move` and `resize`
-    if (!isAgent) {
-      if (target is Window)
-        Toolkit.getDefaultToolkit().systemEventQueue.postEvent(WindowEvent(target, WindowEvent.WINDOW_GAINED_FOCUS))
-      else // TODO: double-check this focus request is necessary for non-Window heavyweight components
-        target.requestFocusInWindow()
-    }
+    transferNativeFocus()
 
     if (PGraphicsEnvironment.clientDoesWindowManagement) {
       AWTAccessor.getComponentAccessor().setLocation(target, x, y)
@@ -297,6 +301,7 @@ class PWindow private constructor(val target: Component, private val isAgent: Bo
     }
 
     fun getWindow(windowId: Int): PWindow? = windows.find { it.id == windowId }
+    fun getWindow(window: Window): PWindow? = windows.find { it.target === window }
 
     @TestOnly
     fun createWithGraphicsOverride(target: Component, isAgent: Boolean, graphicsOverride: Graphics2D?): PWindow {

--- a/projector-awt/src/main/kotlin/org/jetbrains/projector/awt/peer/PWindowPeer.kt
+++ b/projector-awt/src/main/kotlin/org/jetbrains/projector/awt/peer/PWindowPeer.kt
@@ -32,7 +32,6 @@ import java.awt.Dialog
 import java.awt.Point
 import java.awt.Rectangle
 import java.awt.Window
-import java.awt.event.WindowEvent
 import java.awt.peer.WindowPeer
 import kotlin.math.roundToInt
 
@@ -52,10 +51,13 @@ open class PWindowPeer(target: Window) : PContainerPeer(target), WindowPeer {
       targetOwner = targetOwner.owner
     }
 
+    // Fallback: try getting last window that was brought to front
+    if (targetOwner == null) {
+      targetOwner = PWindow.windows.lastOrNull { it !== pWindow && it.target is Window && it.target.isFocusableWindow }?.target as Window?
+    }
+
     if (targetOwner != null) {
-      PKeyboardFocusManagerPeer.setCurrentFocusedWindow(targetOwner)
-      val we = WindowEvent(targetOwner, WindowEvent.WINDOW_GAINED_FOCUS)
-      targetOwner.dispatchEvent(we)
+      PWindow.getWindow(targetOwner)?.transferNativeFocus()
     }
   }
 

--- a/projector-awt/src/main/kotlin/org/jetbrains/projector/awt/peer/PWindowPeer.kt
+++ b/projector-awt/src/main/kotlin/org/jetbrains/projector/awt/peer/PWindowPeer.kt
@@ -53,7 +53,7 @@ open class PWindowPeer(target: Window) : PContainerPeer(target), WindowPeer {
 
     // Fallback: try getting last window that was brought to front
     if (targetOwner == null) {
-      targetOwner = PWindow.windows.lastOrNull { it !== pWindow && it.target is Window && it.target.isFocusableWindow }?.target as Window?
+      targetOwner = PWindow.windows.filter { it !== pWindow }.mapNotNull { it.target as? Window }.lastOrNull(Window::isFocusableWindow)
     }
 
     if (targetOwner != null) {


### PR DESCRIPTION
This keeps focus within windows intact when moving/resizing them instead of transferring focus to the Window component itself