### PR TITLE
Allow specifying server logger factory

### DIFF
--- a/projector-agent/src/main/kotlin/org/jetbrains/projector/agent/GraphicsInterceptor.kt
+++ b/projector-agent/src/main/kotlin/org/jetbrains/projector/agent/GraphicsInterceptor.kt
@@ -30,6 +30,7 @@ import org.jetbrains.projector.awt.peer.PMouseInfoPeer
 import org.jetbrains.projector.awt.service.DrawEventQueue
 import org.jetbrains.projector.common.protocol.toClient.ServerDrawCommandsEvent
 import org.jetbrains.projector.server.ProjectorServer
+import org.jetbrains.projector.server.core.ij.log.DelegatingJvmLogger
 import org.jetbrains.projector.server.service.ProjectorDrawEventQueue
 import org.jetbrains.projector.server.service.ProjectorFontProvider
 import org.jetbrains.projector.util.loading.UseProjectorLoader
@@ -58,7 +59,7 @@ internal object GraphicsInterceptor {
   private var currentQueue: DrawEventQueue? = null
 
   @Suppress("unused")
-  private val server = ProjectorServer.startServer(isAgent = true) {
+  private val server = ProjectorServer.startServer(isAgent = true, ::DelegatingJvmLogger) {
     // todo: make it work with dynamic agent
     //setupAgentSystemProperties()
     //setupAgentSingletons()

--- a/projector-server/CHANGELOG.md
+++ b/projector-server/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+## Added
+- Allow specifying server logger factory
+
 # 1.7.0
 
 ## Added

--- a/projector-server/src/main/kotlin/org/jetbrains/projector/server/ProjectorLauncher.kt
+++ b/projector-server/src/main/kotlin/org/jetbrains/projector/server/ProjectorLauncher.kt
@@ -23,10 +23,12 @@
  */
 package org.jetbrains.projector.server
 
+import org.jetbrains.projector.server.core.ij.log.DelegatingJvmLogger
 import org.jetbrains.projector.server.service.ProjectorFontProvider
 import org.jetbrains.projector.util.loading.ProjectorClassLoaderSetup
 import org.jetbrains.projector.util.loading.UseProjectorLoader
 import org.jetbrains.projector.util.loading.unprotect
+import org.jetbrains.projector.util.logging.Logger
 import java.lang.reflect.Method
 import kotlin.system.exitProcess
 
@@ -108,12 +110,13 @@ object ProjectorLauncher {
     }
 
     @JvmStatic
-    fun runProjectorServer(): Boolean {
+    @JvmOverloads
+    fun runProjectorServer(loggerFactory: (tag: String) -> Logger = ::DelegatingJvmLogger): Boolean {
       System.setProperty(ProjectorServer.ENABLE_PROPERTY_NAME, true.toString())
 
       assert(ProjectorServer.isEnabled) { "Can't start the ${ProjectorServer::class.simpleName} because it's disabled..." }
 
-      val server = ProjectorServer.startServer(isAgent = false) { initializeHeadless() }
+      val server = ProjectorServer.startServer(isAgent = false, loggerFactory) { initializeHeadless() }
 
       Runtime.getRuntime().addShutdownHook(object : Thread() {
 

--- a/projector-server/src/main/kotlin/org/jetbrains/projector/server/ProjectorServer.kt
+++ b/projector-server/src/main/kotlin/org/jetbrains/projector/server/ProjectorServer.kt
@@ -52,7 +52,6 @@ import org.jetbrains.projector.server.core.ij.IdeColors
 import org.jetbrains.projector.server.core.ij.IjInjectorAgentInitializer
 import org.jetbrains.projector.server.core.ij.KeymapSetter
 import org.jetbrains.projector.server.core.ij.SettingsInitializer
-import org.jetbrains.projector.server.core.ij.log.DelegatingJvmLogger
 import org.jetbrains.projector.server.core.ij.md.PanelUpdater
 import org.jetbrains.projector.server.core.protocol.HandshakeTypesSelector
 import org.jetbrains.projector.server.core.protocol.KotlinxJsonToClientHandshakeEncoder
@@ -890,8 +889,8 @@ class ProjectorServer private constructor(
     }
 
     @JvmStatic
-    fun startServer(isAgent: Boolean, initializer: Runnable): ProjectorServer {
-      loggerFactory = { DelegatingJvmLogger(it) }
+    fun startServer(isAgent: Boolean, logFactory: (tag: String) -> Logger, initializer: Runnable): ProjectorServer {
+      loggerFactory = logFactory
 
       ProjectorAwtInitializer.initProjectorAwt()
 


### PR DESCRIPTION
Now when starting server, you can pass a custom logger factory if the default one doesn't fit your needs.